### PR TITLE
Fixed missing dependency pam_krb5.so in Ubuntu;

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -32,7 +32,6 @@ define sssd::domain (
   $ldap_use_tokengroups           = undef, # for murmurhash3, not POSIX GIDs
   $max_id                         = undef,
   $min_id                         = undef,
-  $min_id                         = undef,
   $sudo_provider                  = undef,
   ) {
 

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -4,12 +4,14 @@ define sssd::domain (
   $auth_provider                  = undef, # required
   $autofs_debug_level             = undef,
   $autofs_provider                = undef,
+  $chpass_provider                = undef,
   $cache_credentials              = undef,
   $debug_level                    = undef,
   $dyndns_update                  = false,
   $entry_cache_autofs_timeout     = undef,
   $enumerate                      = undef,
   $id_provider                    = undef, # required
+  $krb5_canonicalize              = undef,
   $krb5_renew_interval            = undef,
   $krb5_renewable_lifetime        = undef,
   $krb_use_fast                   = undef,

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -32,7 +32,8 @@ define sssd::domain (
   $ldap_use_tokengroups           = undef, # for murmurhash3, not POSIX GIDs
   $max_id                         = undef,
   $min_id                         = undef,
-  $use_fqdn                       = undef,
+  $min_id                         = undef,
+  $sudo_provider                  = undef,
   ) {
 
   # Workaround for foreman bug in 1.6.2 host.shortname returns fqdn, we need the shortname

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -1,34 +1,36 @@
+#
 define sssd::domain (
+  $access_provider                = undef,
+  $auth_provider                  = undef, # required
+  $autofs_debug_level             = undef,
+  $autofs_provider                = undef,
+  $cache_credentials              = undef,
   $debug_level                    = undef,
   $dyndns_update                  = false,
-  $autofs_debug_level             = undef,
-  $krb_use_fast                   = undef,
-  $ldap_sasl_authid               = undef, 
-  $krb5_renewable_lifetime        = undef,
-  $krb5_renew_interval 	          = undef,
   $entry_cache_autofs_timeout     = undef,
-  $autofs_provider                = undef,
-  $ldap_autofs_search_base        = undef,
-  $ldap_autofs_map_object_class   = undef,
-  $ldap_autofs_entry_object_class = undef,
-  $ldap_autofs_map_name           = undef,
-  $ldap_autofs_entry_key          = undef,
-  $ldap_autofs_entry_value        = undef,
+  $enumerate                      = undef,
   $id_provider                    = undef, # required
-  $auth_provider                  = undef, # required
-  $cache_credentials              = undef,
-  $access_provider                = undef,
+  $krb5_renew_interval            = undef,
+  $krb5_renewable_lifetime        = undef,
+  $krb_use_fast                   = undef,
   $ldap_access_filter             = undef,
-  $ldap_id_mapping                = undef, # required
-  $min_id                         = undef,
-  $max_id                         = undef,
-  $use_fqdn                       = undef,
-  $ldap_use_tokengroups           = undef, # for murmurhash3, not POSIX GIDs
-  $ldap_id_use_start_tls          = undef,
-  $ldap_sasl_mech                 = undef,
   $ldap_access_order              = undef,
   $ldap_account_expire_policy     = undef,
+  $ldap_autofs_entry_key          = undef,
+  $ldap_autofs_entry_object_class = undef,
+  $ldap_autofs_entry_value        = undef,
+  $ldap_autofs_map_name           = undef,
+  $ldap_autofs_map_object_class   = undef,
+  $ldap_autofs_search_base        = undef,
+  $ldap_id_mapping                = undef, # required
+  $ldap_id_use_start_tls          = undef,
+  $ldap_sasl_authid               = undef,
+  $ldap_sasl_mech                 = undef,
   $ldap_schema                    = undef,
+  $ldap_use_tokengroups           = undef, # for murmurhash3, not POSIX GIDs
+  $max_id                         = undef,
+  $min_id                         = undef,
+  $use_fqdn                       = undef,
   ) {
 
   # Workaround for foreman bug in 1.6.2 host.shortname returns fqdn, we need the shortname
@@ -41,7 +43,6 @@ define sssd::domain (
   else {
     $ldap_sasl_authid_fix = $ldap_sasl_authid
   }
-  
   #notify{"SASL binding to AD as $ldap_sasl_authid":;}
 
   case $::operatingsystem {
@@ -51,7 +52,7 @@ define sssd::domain (
           concat::fragment { "sssd_domain_${name}":
             target  => '/etc/sssd/sssd.conf',
             order   => '05',
-            content => template("sssd/domain.erb"),
+            content => template('sssd/domain.erb'),
           }
         } # 6/7
         default: {
@@ -66,7 +67,7 @@ define sssd::domain (
           concat::fragment { "sssd_domain_${name}":
             target  => '/etc/sssd/sssd.conf',
             order   => '05',
-            content => template("sssd/domain.erb"),
+            content => template('sssd/domain.erb'),
           }
         }
         default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,4 @@
+#
 class sssd::params {
   case $::operatingsystem {
     'debian': {
@@ -7,9 +8,9 @@ class sssd::params {
                           ]
     }
     'ubuntu': {
-      $pkg_list         = [ 'sssd', 'libnss-sss', 'libpam-sss',
-                            'sssd-tools', 'auth-client-config',
-                            'autofs5', 'autofs5-ldap',
+      $pkg_list         = [ 'sssd', 'libnss-sss', 'libpam-sss', 'libpam-krb5',
+                            'sssd-tools', 'auth-client-config', 'autofs5',
+                            'autofs5-ldap',
                           ]
       case $::operatingsystemmajrelease {
         /^15\.\d+/: {
@@ -35,9 +36,9 @@ class sssd::params {
         # If, for some reason, you're running <= 6.5, add libsss_autofs here
         '6': {
           $pkg_list           = [ 'sssd', 'sssd-tools', 'autofs' ]
-          $purge_sssd_file    = { 
+          $purge_sssd_file    = {
                                   '/etc/rc.d/rc.local' => {
-                                    chmod => '0700' 
+                                    chmod => '0700'
                                   }
                                 }
         }

--- a/templates/domain.erb
+++ b/templates/domain.erb
@@ -1,40 +1,34 @@
 [domain/<%= @title %>]
-# Original courtesy of John Hebron, 23-Oct-2012
 
-<% if @debug_level %>debug_level = <%= @debug_level %><% end %>
-
-dyndns_update = <%= @dyndns_update %>
-id_provider = <%= @id_provider %>
+<% if not @access_provider.nil? %>access_provider = <%= @access_provider %><% end %>
 auth_provider = <%= @auth_provider %>
-ldap_schema = <%= @ldap_schema %>
-<% if @access_provider %>access_provider = <%= @access_provider %><% end %>
-
-<% if @ldap_sasl_authid_fix %>ldap_sasl_authid = <%= @ldap_sasl_authid_fix %><% end %>
+<% if not @autofs_provider.nil? %>autofs_provider = <%= @autofs_provider %><% end %>
+<% if not @cache_credentials.nil? %>cache_credentials = <%= @cache_credentials %><% end %>
+<% if not @debug_level.nil? %>debug_level = <%= @debug_level %><% end %>
+dyndns_update = <%= @dyndns_update %>
+<% if not @entry_cache_autofs_timeout.nil? %>entry_cache_autofs_timeout = <%= @entry_cache_autofs_timeout %><% end %>
+<% if not @enumerate.nil? %>enumerate = <%= @enumerate %><% end %>
+id_provider = <%= @id_provider %>
+<% if not @krb5_renew_interval.nil? %>krb5_renew_interval = <%= @krb5_renew_interval %><% end %>
+<% if not @krb5_renewable_lifetime.nil? %>krb5_renewable_lifetime = <%= @krb5_renewable_lifetime %><% end %>
+<% if not @krb_use_fast.nil? %>krb5_use_fast = <%= @krb_use_fast %><% end %>
+<% if not @ldap_autofs_entry_key.nil? %>ldap_autofs_entry_key = <%= @ldap_autofs_entry_key %><% end %>
+<% if not @ldap_autofs_entry_object_class.nil? %>ldap_autofs_entry_object_class = <%= @ldap_autofs_entry_object_class %><% end %>
+<% if not @ldap_autofs_entry_value.nil? %>ldap_autofs_entry_value = <%= @ldap_autofs_entry_value %><% end %>
+<% if not @ldap_autofs_map_name.nil? %>ldap_autofs_map_name = <%= @ldap_autofs_map_name %><% end %>
+<% if not @ldap_autofs_map_object_class.nil? %>ldap_autofs_map_object_class = <%= @ldap_autofs_map_object_class %><% end %>
+<% if not @ldap_autofs_search_base.nil? %>ldap_autofs_search_base = <%= @ldap_autofs_search_base %><% end %>
+<% if not @ldap_id_mapping.nil? %>ldap_id_mapping = <%= @ldap_id_mapping %><% end %>
+<% if not @ldap_id_use_start_tls.nil? %>ldap_id_use_start_tls = <%= @ldap_id_use_start_tls %><% end %>
 ldap_krb5_keytab = /etc/krb5.keytab
-<% if @ldap_id_mapping %>ldap_id_mapping = <%= @ldap_id_mapping %><% end %>
-<% if @cache_credentials %>cache_credentials = <%= @cache_credentials %><% end %>
+<% if not @ldap_sasl_authid_fix.nil? %>ldap_sasl_authid = <%= @ldap_sasl_authid_fix %><% end %>
+<% if not @ldap_sasl_mech.nil? %>ldap_sasl_mech = <%= @ldap_sasl_mech %><% end %>
+ldap_schema = <%= @ldap_schema %>
+<% if not @ldap_use_tokengroups.nil? %>ldap_use_tokengroups = <%= @ldap_use_tokengroups %><% end %>
+<% if not @max_id.nil? %>max_id = <%= @max_id %><% end %>
+<% if not @min_id.nil? %>min_id = <%= @min_id %><% end %>
 
-
-<% if @krb_use_fast %>krb5_use_fast = <%= @krb_use_fast %><% end %>
-<% if @krb5_renewable_lifetime %>krb5_renewable_lifetime = <%= @krb5_renewable_lifetime %><% end %>
-<% if @krb5_renew_interval %>krb5_renew_interval = <%= @krb5_renew_interval %><% end %>
-<% if @ldap_id_use_start_tls %>ldap_id_use_start_tls = <%= @ldap_id_use_start_tls %><% end %>
-<% if @ldap_sasl_mech %>ldap_sasl_mech = <%= @ldap_sasl_mech %><% end %>
-
-<% if @min_id %>min_id = <%= @min_id %><% end %>
-<% if @max_id %>max_id = <%= @max_id %><% end %>
-<% if @ldap_use_tokengroups %>ldap_use_tokengroups = <%= @ldap_use_tokengroups %><% end %>
-
-<% if @autofs_provider %>autofs_provider = <%= @autofs_provider %><% end %>
-<% if @entry_cache_autofs_timeout %>entry_cache_autofs_timeout = <%= @entry_cache_autofs_timeout %><% end %>
-
-<% if @ldap_autofs_search_base %>ldap_autofs_search_base = <%= @ldap_autofs_search_base %><% end %>
-<% if @ldap_autofs_map_object_class %>ldap_autofs_map_object_class = <%= @ldap_autofs_map_object_class %><% end %>
-<% if @ldap_autofs_entry_object_class %>ldap_autofs_entry_object_class = <%= @ldap_autofs_entry_object_class %><% end %>
-<% if @ldap_autofs_map_name %>ldap_autofs_map_name = <%= @ldap_autofs_map_name %><% end %>
-<% if @ldap_autofs_entry_key %>ldap_autofs_entry_key = <%= @ldap_autofs_entry_key %><% end %>
-<% if @ldap_autofs_entry_value %>ldap_autofs_entry_value = <%= @ldap_autofs_entry_value %><% end %>
-
+### Notes ###
 # krb5_use_fast
 #   CentOS 5 = never; CentOS 6 = try
 #

--- a/templates/domain.erb
+++ b/templates/domain.erb
@@ -1,14 +1,15 @@
 [domain/<%= @title %>]
-
 <% if not @access_provider.nil? %>access_provider = <%= @access_provider %><% end %>
 auth_provider = <%= @auth_provider %>
 <% if not @autofs_provider.nil? %>autofs_provider = <%= @autofs_provider %><% end %>
 <% if not @cache_credentials.nil? %>cache_credentials = <%= @cache_credentials %><% end %>
+<% if not @chpass_provider.nil? %>chpass_provider = <%= @chpass_provider %><% end %>
 <% if not @debug_level.nil? %>debug_level = <%= @debug_level %><% end %>
 dyndns_update = <%= @dyndns_update %>
 <% if not @entry_cache_autofs_timeout.nil? %>entry_cache_autofs_timeout = <%= @entry_cache_autofs_timeout %><% end %>
 <% if not @enumerate.nil? %>enumerate = <%= @enumerate %><% end %>
 id_provider = <%= @id_provider %>
+<% if not @krb5_canonicalize.nil? %>krb5_canonicalize = <%= @krb5_canonicalize %><% end %>
 <% if not @krb5_renew_interval.nil? %>krb5_renew_interval = <%= @krb5_renew_interval %><% end %>
 <% if not @krb5_renewable_lifetime.nil? %>krb5_renewable_lifetime = <%= @krb5_renewable_lifetime %><% end %>
 <% if not @krb_use_fast.nil? %>krb5_use_fast = <%= @krb_use_fast %><% end %>

--- a/templates/domain.erb
+++ b/templates/domain.erb
@@ -28,6 +28,11 @@ ldap_schema = <%= @ldap_schema %>
 <% if not @ldap_use_tokengroups.nil? %>ldap_use_tokengroups = <%= @ldap_use_tokengroups %><% end %>
 <% if not @max_id.nil? %>max_id = <%= @max_id %><% end %>
 <% if not @min_id.nil? %>min_id = <%= @min_id %><% end %>
+<% if not @sudo_provider.nil? %>
+# This solves this issue in ubuntu if your not using ldap for sudo
+# https://bugs.launchpad.net/ubuntu/+source/sssd/+bug/1249777
+sudo_provider = <%= @sudo_provider %>
+<% end %>
 
 ### Notes ###
 # krb5_use_fast

--- a/templates/sssd.conf.erb
+++ b/templates/sssd.conf.erb
@@ -1,12 +1,14 @@
-# Courtesy of John Hebron, 23-Oct-2012.
-# Additional comments from https://github.com/Unyonsys/puppet-module-sssd
+# Originally courtesy of John Hebron, 23-Oct-2012.
+# with items pulled from: https://github.com/Unyonsys/puppet-module-sssd
+#
+# Changes by CS, Jan 21, 2016
 
 [sssd]
 config_file_version = 2
 
 # Number of times services should attempt to reconnect in the
 # event of a crash or restart before they give up
-# reconnection_retries = 3
+reconnection_retries = 3
 
 # If a back end is particularly slow you can raise this timeout here
 sbus_timeout = 30
@@ -28,15 +30,6 @@ reconnection_retries = 3
 vetoed_shells = /bin/csh
 shell_fallback = /bin/bash
 
-# The entry_cache_timeout indicates the number of seconds to retain an
-# entry in cache before it is considered stale and must block to refresh.
-# The entry_cache_nowait_timeout indicates the number of seconds to
-# wait before updating the cache out-of-band. (NSS requests will still
-# be returned from cache until the full entry_cache_timeout). Setting this
-# value to 0 turns this feature off (default).
-; entry_cache_timeout = 600
-; entry_cache_nowait_timeout = 300
-
 [pam]
 reconnection_retries = 3
 
@@ -45,8 +38,5 @@ reconnection_retries = 3
 # [autofs] must be declared if you intend to use it
 # even if there are no parameters under [autofs]
 
-
 <% if @autofs_debug_level %>debug_level = <%= @autofs_debug_level %><% end %>
-
-
 <% end %>

--- a/templates/sssd.conf.erb
+++ b/templates/sssd.conf.erb
@@ -25,6 +25,8 @@ domains = <%= @domains.join(',').chomp(',') %>
 filter_groups = root
 filter_users = root
 reconnection_retries = 3
+vetoed_shells = /bin/csh
+shell_fallback = /bin/bash
 
 # The entry_cache_timeout indicates the number of seconds to retain an
 # entry in cache before it is considered stale and must block to refresh.


### PR DESCRIPTION
This template file templates/sss.erb (account required pam_krb5.so minimum_uid=1000) requires pam_krb5.so be installed;

It's not by default; added libpam-krb5 to pkg_list fixs this error:
 : PAM unable to dlopen(pam_krb5.so): /lib/security/pam_krb5.so: cannot open shared object file: No such file or directory
 : PAM adding faulty module: pam_krb5.so
